### PR TITLE
Fix: switch module path to fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/soheilhy/cmux
+module github.com/exaring/cmux
 
 go 1.11
 


### PR DESCRIPTION
```
go: github.com/exaring/cmux@v0.1.5: parsing go.mod:
        module declares its path as: github.com/soheilhy/cmux
                but was required as: github.com/exaring/cmux
```